### PR TITLE
Support "Get USB device status command"

### DIFF
--- a/nuvoton_defs.hpp
+++ b/nuvoton_defs.hpp
@@ -21,9 +21,19 @@
 #define LENGTH_32BIT              32
 #define LENGTH_64BIT              64
 
+#define SUCCESS                   0x0
+
 #define PDID                      0xf0800000
+
 #define PWRON                     0xf0800004
+
 #define SPSWC                     0xf0800038
+
+#define USB_BASE                  0xf0830000
+#define USB_CTL_START             0
+#define USB_CTL_END               9
+#define USB_OFFSET                0x1000
+#define USB_DEVICE_ADDR           0x154
 
 #define GEN_MASK                  0xff000000
 #define SPSWC_MASK                0x00000007

--- a/oemcommands.hpp
+++ b/oemcommands.hpp
@@ -30,7 +30,10 @@ static constexpr NetFn netFnApp = netFnOemEight;
 namespace general
 {
 static constexpr Cmd cmdGetStrapPinStatus = 0x02;
-static constexpr Cmd cmdGetUartMode = 0x03;
+
+static constexpr Cmd cmdGetUartMode = 0x04;
+
+static constexpr Cmd cmdGetUsbDeviceStatus = 0x06;
 
 } // namespace general
 


### PR DESCRIPTION
1. E.g.: Check udc9 device status: ipmitool raw 0x30 0x6 0x9
   ret:  00 --> connected

Change "Get Uart Mode" command" command id

1. E.g.: ipmitool raw 0x30 0x4
   ret:  00 --> mode 1
         06 --> mode 7

Signed-off-by: kfting <kfting@nuvoton.com>