### PR TITLE
Support "Get BMC reboot reason" command

### DIFF
--- a/nuvoton_defs.hpp
+++ b/nuvoton_defs.hpp
@@ -29,6 +29,13 @@
 
 #define SPSWC                     0xf0800038
 
+#define MFSEL1                    0xf080000C
+#define MFSEL2                    0xf0800010
+#define MFSEL3                    0xf0800064
+#define MFSEL4                    0xf08000B0
+
+#define INTCR2                    0xf0800060
+
 #define USB_BASE                  0xf0830000
 #define USB_CTL_START             0
 #define USB_CTL_END               9
@@ -37,3 +44,4 @@
 
 #define GEN_MASK                  0xff000000
 #define SPSWC_MASK                0x00000007
+#define BIT_MASK                  0x00000001

--- a/oemcommands.hpp
+++ b/oemcommands.hpp
@@ -18,6 +18,223 @@
 
 #include <ipmid/api-types.hpp>
 
+#define GPIO_NUM  256
+
+struct gpio_lookup
+{
+    uint32_t mfselReg;
+    uint8_t  offset;
+};
+
+struct gpio_lookup gpioLUT[GPIO_NUM] =
+{
+    // gpio 0 - 3
+    {MFSEL1, 30},
+    {MFSEL1, 30},
+    {MFSEL1, 30},
+    {MFSEL1, 30},
+
+    // gpio 12 - 15
+    {MFSEL1, 24},
+    {MFSEL1, 24},
+    {MFSEL1, 24},
+    {MFSEL1, 24},
+
+    // gpio 20
+    {MFSEL2, 24},
+
+    // gpio 21
+    {MFSEL2, 25},
+
+    // gpio 22
+    {MFSEL2, 26},
+
+    // gpio 23
+    {MFSEL2, 27},
+
+
+    // gpio 26-27
+    {MFSEL1, 2},
+    {MFSEL1, 2},
+
+    // gpio 28-29
+    {MFSEL1, 1},
+    {MFSEL1, 1},
+
+    // gpio 30-31
+    {MFSEL1, 0},
+    {MFSEL1, 0},
+
+    // gpio 32
+    {MFSEL1, 3},
+
+    // gpio 41-42
+    {MFSEL1, 9},
+    {MFSEL1, 9},
+
+    // gpo  45
+    {MFSEL1, 10},
+
+    // gpio 46-47
+    {MFSEL1, 10},
+    {MFSEL1, 10},
+
+
+    // gpo  48
+    {MFSEL1, 11},
+
+    // gpio 49-55
+    {MFSEL1, 11},
+    {MFSEL1, 11},
+    {MFSEL1, 11},
+    {MFSEL1, 11},
+    {MFSEL1, 11},
+    {MFSEL1, 11},
+    {MFSEL1, 11},
+
+    // gpio 56
+    {MFSEL1, 12},
+
+    // gpio 57-58
+    {MFSEL1, 13},
+    {MFSEL1, 13},
+
+    // gpio 59
+    {MFSEL2, 30},
+
+    // gpio 60
+    {MFSEL2, 31},
+
+    // gpo  61
+    {MFSEL1, 10},
+
+    // gpio 64
+    {MFSEL2, 0},
+
+    // gpio 65
+    {MFSEL2, 1},
+
+    // gpio 66
+    {MFSEL2, 2},
+
+    // gpio 67
+    {MFSEL2, 3},
+
+    // gpio 68
+    {MFSEL2, 4},
+
+    // gpio 69
+    {MFSEL2, 5},
+
+    // gpio 70
+    {MFSEL2, 6},
+
+    // gpio 71
+    {MFSEL2, 7},
+
+    // gpio 72
+    {MFSEL2, 8},
+
+    // gpio 73
+    {MFSEL2, 9},
+
+    // gpio 74
+    {MFSEL2, 10},
+
+    // gpio 75
+    {MFSEL2, 11},
+
+    // gpio 76
+    {MFSEL2, 12},
+
+    // gpio 77
+    {MFSEL2, 13},
+
+    // gpio 78
+    {MFSEL2, 14},
+
+    // gpio 79
+    {MFSEL2, 15},
+
+    // gpio 80
+    {MFSEL2, 16},
+
+    // gpio 81
+    {MFSEL2, 17},
+
+    // gpio 82
+    {MFSEL2, 18},
+
+    // gpio 83
+    {MFSEL2, 19},
+
+    // gpio 84-89
+    {MFSEL1, 14},
+    {MFSEL1, 14},
+    {MFSEL1, 14},
+    {MFSEL1, 14},
+    {MFSEL1, 14},
+    {MFSEL1, 14},
+
+    // gpio 90
+    {MFSEL1, 15},
+
+    // gpio 91-92
+    {MFSEL1, 16},
+    {MFSEL1, 16},
+
+    // gpio 93-94
+    {MFSEL1, 17},
+    {MFSEL1, 17},
+
+    // gpio 95
+    {MFSEL1, 26},
+
+    // gpio 114-115
+    {MFSEL1, 6},
+    {MFSEL1, 6},
+
+    // gpio 116-117
+    {MFSEL1, 7},
+    {MFSEL1, 7},
+
+    // gpio 118-119
+    {MFSEL1, 8},
+    {MFSEL1, 8},
+
+    // gpio 144
+    {MFSEL2, 20},
+
+    // gpio 145
+    {MFSEL2, 21},
+
+    // gpio 146
+    {MFSEL2, 22},
+
+    // gpio 147
+    {MFSEL2, 23},
+
+    // gpio 160
+    {MFSEL1, 21},
+
+    // gpio 161
+    {MFSEL1, 26},
+
+    // gpio 163-167
+    {MFSEL1, 26},
+    {MFSEL1, 26},
+    {MFSEL1, 26},
+    {MFSEL1, 26},
+    {MFSEL1, 26},
+
+    // gpio 170
+    {MFSEL1, 22},
+
+    // gpio 200
+    {MFSEL1, 14},
+
+};
+
 namespace ipmi
 {
 namespace nuvoton
@@ -35,6 +252,9 @@ static constexpr Cmd cmdGetUartMode = 0x04;
 
 static constexpr Cmd cmdGetUsbDeviceStatus = 0x06;
 
+static constexpr Cmd cmdGetGpioStatus = 0x08;
+
+static constexpr Cmd cmdGetBmcRebootReason = 0x0a;
 } // namespace general
 
 } // namespace nuvoton


### PR DESCRIPTION
1. E.g.: ipmitool raw 0x30 0xa
   ret:  7f // It's the value from the 24th bit to 31st bit of INTCR2 register.
         80 // It's the value from the 16th bit to 23rd bit of INTCR2 register.
            // The value 0 of each bit means that it's active;otherwise, it's inactive.

Signed-off-by: kfting <kfting@nuvoton.com>