### PR TITLE
Support "Get image location status" command

### DIFF
--- a/nuvoton_defs.hpp
+++ b/nuvoton_defs.hpp
@@ -42,6 +42,13 @@
 #define USB_OFFSET                0x1000
 #define USB_DEVICE_ADDR           0x154
 
+#define ROM_CODE_STATUS           0xf084bffc
+#define ST_ROM_USE_IMAGE_SPI0_CS0_OFFSET_0     0x21
+#define ST_ROM_USE_IMAGE_SPI0_CS0_OFFSET_80000 0x22
+#define ST_ROM_USE_IMAGE_SPI0_CS1_OFFSET_0     0x23
+#define FLASH_0                   0
+#define FLASH_1                   1
+
 #define GEN_MASK                  0xff000000
 #define SPSWC_MASK                0x00000007
 #define BIT_MASK                  0x00000001

--- a/oemcommands.cpp
+++ b/oemcommands.cpp
@@ -90,6 +90,27 @@ uint64_t devmem_read(off_t target, unsigned width, bool &ret)
     return read_result;
 }
 
+ipmi::RspType<uint8_t> ipmiOEMGetImageLocationStatus (void)
+{
+    bool ret;
+    uint64_t read_result = devmem_read(ROM_CODE_STATUS, LENGTH_32BIT, ret);
+    if (ret)
+    {
+        switch ((uint8_t)read_result)
+        {
+            case ST_ROM_USE_IMAGE_SPI0_CS0_OFFSET_0:
+            case ST_ROM_USE_IMAGE_SPI0_CS0_OFFSET_80000:
+                return ipmi::responseSuccess(FLASH_0);
+            case ST_ROM_USE_IMAGE_SPI0_CS1_OFFSET_0:
+                return ipmi::responseSuccess(FLASH_1);
+            default:
+                return ipmi::responseResponseError();
+        }
+    }
+    else
+        return ipmi::responseResponseError();
+}
+
 ipmi::RspType<uint8_t,
               uint8_t
              >
@@ -192,6 +213,11 @@ static void registerOEMFunctions(void)
     registerHandler(prioOemBase, nuvoton::netFnGeneral,
                       nuvoton::general::cmdGetBmcRebootReason, Privilege::Callback,
                       ipmiOEMGetBmcRebootReason);
+
+    // <Get image location status command>
+    registerHandler(prioOemBase, nuvoton::netFnGeneral,
+                      nuvoton::general::cmdGetImageLocationStatus, Privilege::Callback,
+                      ipmiOEMGetImageLocationStatus);
 
 }
 

--- a/oemcommands.hpp
+++ b/oemcommands.hpp
@@ -255,6 +255,8 @@ static constexpr Cmd cmdGetUsbDeviceStatus = 0x06;
 static constexpr Cmd cmdGetGpioStatus = 0x08;
 
 static constexpr Cmd cmdGetBmcRebootReason = 0x0a;
+
+static constexpr Cmd cmdGetImageLocationStatus = 0x0c;
 } // namespace general
 
 } // namespace nuvoton


### PR DESCRIPTION
1. E.g.: ipmitool raw 0x30 0xc
         ret: 00 // boot from the first flash
              01 // boot from the second flash

Signed-off-by: kfting <kfting@nuvoton.com>