### PR TITLE
Support "GPIO status" command

### DIFF
--- a/nuvoton_defs.hpp
+++ b/nuvoton_defs.hpp
@@ -23,6 +23,29 @@
 
 #define SUCCESS                   0x0
 
+#define GPIO0                     0xf0010000
+#define GPIO1                     0xf0011000
+#define GPIO2                     0xf0012000
+#define GPIO3                     0xf0013000
+#define GPIO4                     0xf0014000
+#define GPIO5                     0xf0015000
+#define GPIO6                     0xf0016000
+#define GPIO7                     0xf0017000
+
+#define GPIO_OFFSET               0x1000
+#define GPIO_NUM_IN_GROUP         32
+
+#define GP_DOUT_OFFSET            0xc
+#define GP_OE_OFFSET              0x10
+
+#define GP_DIN_OFFSET             0x4
+#define GP_IEM_OFFSET             0x58
+
+#define GP_DIR_OUTPUT             0x1
+#define GP_DIR_INPUT              0x0
+#define GP_LEVEL_HIGH             0x1
+#define GP_LEVEL_LOW              0x1
+
 #define PDID                      0xf0800000
 
 #define PWRON                     0xf0800004
@@ -35,6 +58,8 @@
 #define MFSEL4                    0xf08000B0
 
 #define INTCR2                    0xf0800060
+
+#define FLOCKR1                   0xf0800074
 
 #define USB_BASE                  0xf0830000
 #define USB_CTL_START             0

--- a/oemcommands.hpp
+++ b/oemcommands.hpp
@@ -20,218 +20,2093 @@
 
 #define GPIO_NUM  256
 
+#define DEF_NONE  254
+#define DEF_GPIO  255
+
 struct gpio_lookup
 {
-    uint32_t mfselReg;
-    uint8_t  offset;
+    // The value of the pin is expected to be configured as a gpio
+    uint8_t  refValue;
+
+    // The number of bits for the pin to be checked under the bitwise mask
+    // operation
+    uint8_t  maskBit;
+
+    uint32_t reg;
+    uint8_t  offSet;
+
+    struct gpio_lookup *next;
+};
+
+
+struct gpio_lookup gpio_20_1 =
+{
+    0,
+    1,
+    MFSEL2,24,
+    NULL
+};
+
+struct gpio_lookup gpio_21_1 =
+{
+    0,
+    1,
+    MFSEL2,25,
+    NULL
+};
+
+struct gpio_lookup gpio_22_1 =
+{
+    0,
+    1,
+    MFSEL2,26,
+    NULL
+};
+
+struct gpio_lookup gpio_23_1 =
+{
+    0,
+    1,
+    MFSEL2,27,
+    NULL
+};
+
+struct gpio_lookup gpio_24_1 =
+{
+    0,
+    1,
+    MFSEL3,18,
+    NULL
+};
+
+struct gpio_lookup gpio_25_1 =
+{
+    0,
+    1,
+    MFSEL3,18,
+    NULL
+};
+
+struct gpio_lookup gpio_43_44_2 =
+{
+    0,
+    1,
+    MFSEL1,10,
+    NULL
+};
+
+struct gpio_lookup gpio_43_44_1 =
+{
+    0,
+    1,
+    MFSEL4,0,
+    &gpio_43_44_2
+};
+
+struct gpio_lookup gpio_45_1 =
+{
+    0,
+    1,
+    MFSEL1,10,
+    NULL
+};
+
+struct gpio_lookup gpio_46_47_1 =
+{
+    0,
+    1,
+    MFSEL1,10,
+    NULL
+};
+
+struct gpio_lookup gpio_48_1 =
+{
+    0,
+    1,
+    MFSEL1,11,
+    NULL
+};
+
+struct gpio_lookup gpio_49_1 =
+{
+    0,
+    1,
+    MFSEL1,11,
+    NULL
+};
+
+struct gpio_lookup gpio_62_1 =
+{
+    0,
+    1,
+    MFSEL1,10,
+    NULL
+};
+
+struct gpio_lookup gpio_63_1 =
+{
+    0,
+    1,
+    MFSEL1,10,
+    NULL
+};
+
+struct gpio_lookup gpio_110_113_1 =
+{
+    0,
+    1,
+    MFSEL4,24,
+    NULL
+};
+
+struct gpio_lookup gpio_155_1 =
+{
+     0,
+     1,
+     MFSEL3,25,
+     NULL
+};
+
+
+
+struct gpio_lookup gpio_168_1 =
+{
+    0,
+    1,
+    MFSEL4,8,
+    NULL
+};
+
+struct gpio_lookup gpio_188_1 =
+{
+     0,
+     1,
+     MFSEL4,20,
+     NULL
+};
+
+struct gpio_lookup gpio_189_1 =
+{
+     0,
+     1,
+     MFSEL4,20,
+     NULL
 };
 
 struct gpio_lookup gpioLUT[GPIO_NUM] =
 {
-    // gpio 0 - 3
-    {MFSEL1, 30},
-    {MFSEL1, 30},
-    {MFSEL1, 30},
-    {MFSEL1, 30},
+    // gpio 0-3
+    {
+     0,
+     1,
+     MFSEL1,30,
+     NULL
+    },
 
-    // gpio 12 - 15
-    {MFSEL1, 24},
-    {MFSEL1, 24},
-    {MFSEL1, 24},
-    {MFSEL1, 24},
+    {
+     0,
+     1,
+     MFSEL1,30,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,30,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,30,
+     NULL
+    },
+
+    // gpio 4-7
+    {
+     0,
+     1,
+     MFSEL3,14,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,14,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,14,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,14,
+     NULL
+    },
+
+    // gpio 8
+    {
+     0,
+     1,
+     FLOCKR1,4,
+     NULL
+    },
+
+    // gpio 9
+    {
+     0,
+     1,
+     FLOCKR1,8,
+     NULL
+    },
+
+    // gpio 10-11
+    {
+     0,
+     1,
+     MFSEL3,18,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,18,
+     NULL
+    },
+
+    // gpio 12-15
+    {
+     0,
+     1,
+     MFSEL1,24,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,24,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,24,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,24,
+     NULL
+    },
+
+    // gpio 16
+    {
+     0,
+     1,
+     FLOCKR1,0,
+     NULL
+    },
+
+    // gpio 17-19
+    {
+     0,
+     1,
+     MFSEL3,13,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,13,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,13,
+     NULL
+    },
 
     // gpio 20
-    {MFSEL2, 24},
+    {
+     0,
+     1,
+     MFSEL3,8,
+     &gpio_20_1
+    },
 
     // gpio 21
-    {MFSEL2, 25},
+    {
+     0,
+     1,
+     MFSEL3,8,
+     &gpio_21_1
+    },
 
     // gpio 22
-    {MFSEL2, 26},
+    {
+     0,
+     1,
+     MFSEL3,7,
+     &gpio_22_1
+    },
 
     // gpio 23
-    {MFSEL2, 27},
+    {
+     0,
+     1,
+     MFSEL3,7,
+     &gpio_23_1
+    },
 
+    // gpio 24
+    {
+     0,
+     1,
+     MFSEL2,28,
+     &gpio_24_1
+    },
+
+    // gpio 25
+    {
+     0,
+     1,
+     MFSEL2,29,
+     &gpio_25_1
+    },
 
     // gpio 26-27
-    {MFSEL1, 2},
-    {MFSEL1, 2},
+    {
+     0,
+     1,
+     MFSEL1,2,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,2,
+     NULL
+    },
 
     // gpio 28-29
-    {MFSEL1, 1},
-    {MFSEL1, 1},
+    {
+     0,
+     1,
+     MFSEL1,1,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,1,
+     NULL
+    },
 
     // gpio 30-31
-    {MFSEL1, 0},
-    {MFSEL1, 0},
+    {
+     0,
+     1,
+     MFSEL1,0,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,0,
+     NULL
+    },
 
     // gpio 32
-    {MFSEL1, 3},
+    {
+     0,
+     1,
+     MFSEL1,3,
+     NULL
+    },
+
+    // gpio 33-36
+    // not connected to pins
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    // gpio 37-40
+    // no mfsel
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
 
     // gpio 41-42
-    {MFSEL1, 9},
-    {MFSEL1, 9},
+    {
+     0,
+     1,
+     MFSEL1,9,
+     NULL
+    },
 
-    // gpo  45
-    {MFSEL1, 10},
+    {
+     0,
+     1,
+     MFSEL1,9,
+     NULL
+    },
+
+    // gpio 43-44
+    {
+     0,
+     1,
+     MFSEL3,24,
+     &gpio_43_44_1
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,24,
+     &gpio_43_44_1
+    },
+
+    // gpio 45
+    {
+     0,
+     1,
+     MFSEL4,0,
+     &gpio_45_1
+    },
 
     // gpio 46-47
-    {MFSEL1, 10},
-    {MFSEL1, 10},
+    {
+     0,
+     1,
+     MFSEL4,0,
+     &gpio_46_47_1
+    },
 
+    {
+     0,
+     1,
+     MFSEL4,0,
+     &gpio_46_47_1
+    },
 
-    // gpo  48
-    {MFSEL1, 11},
+    // gpio  48
+    {
+     0,
+     1,
+     MFSEL4,1,
+     &gpio_48_1
+    },
 
     // gpio 49-55
-    {MFSEL1, 11},
-    {MFSEL1, 11},
-    {MFSEL1, 11},
-    {MFSEL1, 11},
-    {MFSEL1, 11},
-    {MFSEL1, 11},
-    {MFSEL1, 11},
+    {
+     0,
+     1,
+     MFSEL4,1,
+     &gpio_49_1
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,11,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,11,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,11,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,11,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,11,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,11,
+     NULL
+    },
 
     // gpio 56
-    {MFSEL1, 12},
+    {
+     0,
+     1,
+     MFSEL1,12,
+     NULL
+    },
 
     // gpio 57-58
-    {MFSEL1, 13},
-    {MFSEL1, 13},
+    {
+     0,
+     1,
+     MFSEL1,13,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,13,
+     NULL
+    },
 
     // gpio 59
-    {MFSEL2, 30},
+    {
+     0,
+     1,
+     MFSEL2,30,
+     NULL
+    },
 
     // gpio 60
-    {MFSEL2, 31},
+    {
+     0,
+     1,
+     MFSEL2,31,
+     NULL
+    },
 
-    // gpo  61
-    {MFSEL1, 10},
+    // gpo 61
+    {
+     0,
+     1,
+     MFSEL1,10,
+     NULL
+    },
+
+    // gpo 62
+    {
+     0,
+     1,
+     MFSEL3,24,
+     &gpio_62_1
+    },
+
+    // gpo 63
+    {
+     0,
+     1,
+     MFSEL3,24,
+     &gpio_63_1
+    },
 
     // gpio 64
-    {MFSEL2, 0},
+    {
+     0,
+     1,
+     MFSEL2,0,
+     NULL
+    },
 
     // gpio 65
-    {MFSEL2, 1},
+    {
+     0,
+     1,
+     MFSEL2,1,
+     NULL
+    },
 
     // gpio 66
-    {MFSEL2, 2},
+    {
+     0,
+     1,
+     MFSEL2,2,
+     NULL
+    },
 
     // gpio 67
-    {MFSEL2, 3},
+    {
+     0,
+     1,
+     MFSEL2,3,
+     NULL
+    },
 
     // gpio 68
-    {MFSEL2, 4},
+    {
+     0,
+     1,
+     MFSEL2,4,
+     NULL
+    },
 
     // gpio 69
-    {MFSEL2, 5},
+    {
+     0,
+     1,
+     MFSEL2,5,
+     NULL
+    },
 
     // gpio 70
-    {MFSEL2, 6},
+    {
+     0,
+     1,
+     MFSEL2,6,
+     NULL
+    },
 
     // gpio 71
-    {MFSEL2, 7},
+    {
+     0,
+     1,
+     MFSEL2,7,
+     NULL
+    },
 
     // gpio 72
-    {MFSEL2, 8},
+    {
+     0,
+     1,
+     MFSEL2,8,
+     NULL
+    },
 
     // gpio 73
-    {MFSEL2, 9},
+    {
+     0,
+     1,
+     MFSEL2,9,
+     NULL
+    },
 
     // gpio 74
-    {MFSEL2, 10},
+    {
+     0,
+     1,
+     MFSEL2,10,
+     NULL
+    },
 
     // gpio 75
-    {MFSEL2, 11},
+    {
+     0,
+     1,
+     MFSEL2,11,
+     NULL
+    },
 
     // gpio 76
-    {MFSEL2, 12},
+    {
+     0,
+     1,
+     MFSEL2,12,
+     NULL
+    },
 
     // gpio 77
-    {MFSEL2, 13},
+    {
+     0,
+     1,
+     MFSEL2,13,
+     NULL
+    },
 
     // gpio 78
-    {MFSEL2, 14},
+    {
+     0,
+     1,
+     MFSEL2,14,
+     NULL
+    },
 
     // gpio 79
-    {MFSEL2, 15},
+    {
+     0,
+     1,
+     MFSEL2,15,
+     NULL
+    },
+
 
     // gpio 80
-    {MFSEL2, 16},
+    {
+     0,
+     1,
+     MFSEL2,16,
+     NULL
+    },
 
     // gpio 81
-    {MFSEL2, 17},
+    {
+     0,
+     1,
+     MFSEL2,17,
+     NULL
+    },
 
     // gpio 82
-    {MFSEL2, 18},
+    {
+     0,
+     1,
+     MFSEL2,18,
+     NULL
+    },
 
     // gpio 83
-    {MFSEL2, 19},
+    {
+     0,
+     1,
+     MFSEL2,19,
+     NULL
+    },
 
     // gpio 84-89
-    {MFSEL1, 14},
-    {MFSEL1, 14},
-    {MFSEL1, 14},
-    {MFSEL1, 14},
-    {MFSEL1, 14},
-    {MFSEL1, 14},
+    {
+     0,
+     1,
+     MFSEL1,14,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,14,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,14,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,14,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,14,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,14,
+     NULL
+    },
 
     // gpio 90
-    {MFSEL1, 15},
+    {
+     0,
+     1,
+     MFSEL1,15,
+     NULL
+    },
 
     // gpio 91-92
-    {MFSEL1, 16},
-    {MFSEL1, 16},
+    {
+     0,
+     1,
+     MFSEL1,16,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,16,
+     NULL
+    },
 
     // gpio 93-94
-    {MFSEL1, 17},
-    {MFSEL1, 17},
+    {
+     0,
+     1,
+     MFSEL1,17,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,17,
+     NULL
+    },
 
     // gpio 95
-    {MFSEL1, 26},
+    {
+     1,
+     1,
+     MFSEL1,26,
+     NULL
+    },
+
+    // gpio 96-107
+    {
+     0,
+     1,
+     MFSEL4,22,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,22,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,22,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,22,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,22,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,22,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,22,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,22,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,22,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,22,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,22,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,22,
+     NULL
+    },
+
+    // gpio 108-109
+    {
+     0,
+     1,
+     MFSEL4,21,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,21,
+     NULL
+    },
+
+    // gpio 110-113
+    {
+     0,
+     1,
+     MFSEL3,26,
+     &gpio_110_113_1
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,26,
+     &gpio_110_113_1
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,26,
+     &gpio_110_113_1
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,26,
+     &gpio_110_113_1
+    },
 
     // gpio 114-115
-    {MFSEL1, 6},
-    {MFSEL1, 6},
+    {
+     0,
+     1,
+     MFSEL1,6,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,6,
+     NULL
+    },
 
     // gpio 116-117
-    {MFSEL1, 7},
-    {MFSEL1, 7},
+    {
+     0,
+     1,
+     MFSEL1,7,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,7,
+     NULL
+    },
 
     // gpio 118-119
-    {MFSEL1, 8},
-    {MFSEL1, 8},
+    {
+     0,
+     1,
+     MFSEL1,8,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL1,8,
+     NULL
+    },
+
+    // gpio 120-127
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    // gpio 128-129
+    {
+     0,
+     1,
+     MFSEL4,11,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,11,
+     NULL
+    },
+
+    // gpio 130-131
+    {
+     0,
+     1,
+     MFSEL4,12,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,12,
+     NULL
+    },
+
+    // gpio 132-133
+    {
+     0,
+     1,
+     MFSEL4,13,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,13,
+     NULL
+    },
+
+    // gpio 134-135
+    {
+     0,
+     1,
+     MFSEL4,14,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,14,
+     NULL
+    },
+
+    // gpio 136-139
+    {
+     0,
+     1,
+     MFSEL3,12,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,12,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,12,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,12,
+     NULL
+    },
+
+    // gpio 140-143
+    {
+     0,
+     1,
+     MFSEL3,12,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,12,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,12,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,12,
+     NULL
+    },
 
     // gpio 144
-    {MFSEL2, 20},
+    {
+     0,
+     1,
+     MFSEL2,20,
+     NULL
+    },
 
     // gpio 145
-    {MFSEL2, 21},
+    {
+     0,
+     1,
+     MFSEL2,21,
+     NULL
+    },
 
     // gpio 146
-    {MFSEL2, 22},
+    {
+     0,
+     1,
+     MFSEL2,22,
+     NULL
+    },
 
     // gpio 147
-    {MFSEL2, 23},
+    {
+     0,
+     1,
+     MFSEL2,23,
+     NULL
+    },
+
+    // gpio 148-151
+    {
+     0,
+     1,
+     MFSEL3,11,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,11,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,11,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,11,
+     NULL
+    },
+
+    // gpio 152
+    {
+     0,
+     1,
+     MFSEL3,10,
+     NULL
+    },
+
+    // gpio 153
+    {
+     0,
+     1,
+     FLOCKR1,24,
+     NULL
+    },
+
+    // gpio 154
+    {
+     0,
+     1,
+     MFSEL3,10,
+     NULL
+    },
+
+    // gpio 155
+    {
+     0,
+     1,
+     MFSEL4,6,
+     &gpio_155_1
+    },
+
+    // gpio 156-159
+    {
+     0,
+     1,
+     MFSEL3,10,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,10,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,10,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,10,
+     NULL
+    },
 
     // gpio 160
-    {MFSEL1, 21},
+    {
+     0,
+     1,
+     MFSEL1,21,
+     NULL
+    },
 
     // gpio 161
-    {MFSEL1, 26},
+    {
+     1,
+     1,
+     MFSEL1,26,
+     NULL
+    },
+
+    // gpio 162
+    {
+     1,
+     1,
+     MFSEL1,31,
+     NULL
+    },
 
     // gpio 163-167
-    {MFSEL1, 26},
-    {MFSEL1, 26},
-    {MFSEL1, 26},
-    {MFSEL1, 26},
-    {MFSEL1, 26},
+    {
+     1,
+     1,
+     MFSEL1,26,
+     NULL
+    },
+
+    {
+     1,
+     1,
+     MFSEL1,26,
+     NULL
+    },
+
+    {
+     1,
+     1,
+     MFSEL1,26,
+     NULL
+    },
+
+    {
+     1,
+     1,
+     MFSEL1,26,
+     NULL
+    },
+
+    {
+     1,
+     1,
+     MFSEL1,26,
+     NULL
+    },
+
+    // gpio 168
+    {
+     1,
+     1,
+     MFSEL3,16,
+     &gpio_168_1
+    },
+
+    // gpio 169
+    {
+     0,
+     1,
+     MFSEL3,0,
+     NULL
+    },
 
     // gpio 170
-    {MFSEL1, 22},
+    {
+     0,
+     1,
+     MFSEL1,22,
+     NULL
+    },
+
+    // gpio 171-172
+    {
+     0,
+     1,
+     MFSEL3,1,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,1,
+     NULL
+    },
+
+    // gpio 173-174
+    {
+     0,
+     1,
+     MFSEL3,2,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,2,
+     NULL
+    },
+
+    // gpio 175-177
+    {
+     0,
+     2,
+     MFSEL3,3,
+     NULL
+    },
+
+    {
+     0,
+     2,
+     MFSEL3,3,
+     NULL
+    },
+
+    {
+     0,
+     2,
+     MFSEL3,3,
+     NULL
+    },
+
+    // gpio 178-182
+    {
+     0,
+     1,
+     MFSEL3,9,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,9,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,9,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,9,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,9,
+     NULL
+    },
+
+    // gpio 183-186
+    {
+     0,
+     1,
+     MFSEL4,16,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,16,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,16,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,16,
+     NULL
+    },
+
+    // gpio 187
+    {
+     0,
+     1,
+     MFSEL4,17,
+     NULL
+    },
+
+    // gpio 188
+    {
+     0,
+     1,
+     MFSEL4,18,
+     &gpio_188_1
+    },
+
+    // gpio 189
+    {
+     0,
+     1,
+     MFSEL4,19,
+     &gpio_189_1
+    },
+
+    // gpio 190
+    {
+     1,
+     1,
+     FLOCKR1,20,
+     NULL
+    },
+
+    // gpio 191-192
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    // gpio 193
+    {
+     0,
+     1,
+     MFSEL3,9,
+     NULL
+    },
+
+    // gpio 194-199
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
 
     // gpio 200
-    {MFSEL1, 14},
+    {
+     0,
+     1,
+     MFSEL1,14,
+     NULL
+    },
+
+    // gpio 201
+    {
+     0,
+     1,
+     MFSEL3,9,
+     NULL
+    },
+
+    // gpio 202
+    {
+     DEF_GPIO,
+     0,
+     0,0,
+     NULL
+    },
+
+    // gpio 203
+    {
+     0,
+     1,
+     MFSEL3,3,
+     NULL
+    },
+
+    // gpio 204-207
+    {
+     1,
+     1,
+     MFSEL3,22,
+     NULL
+    },
+
+    {
+     1,
+     1,
+     MFSEL3,22,
+     NULL
+    },
+
+    {
+     1,
+     1,
+     MFSEL3,22,
+     NULL
+    },
+
+    {
+     1,
+     1,
+     MFSEL3,22,
+     NULL
+    },
+
+    // gpio 208-215
+    {
+     0,
+     1,
+     MFSEL3,26,
+     &gpio_110_113_1
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,26,
+     &gpio_110_113_1
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,26,
+     &gpio_110_113_1
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,26,
+     &gpio_110_113_1
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,26,
+     &gpio_110_113_1
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,26,
+     &gpio_110_113_1
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,26,
+     &gpio_110_113_1
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,26,
+     &gpio_110_113_1
+    },
+
+
+    // gpio 216
+    {
+     0,
+     1,
+     MFSEL4,23,
+     NULL
+    },
+
+    // gpio 217
+    {
+     0,
+     1,
+     MFSEL4,23,
+     NULL
+    },
+
+    // gpio 218
+    {
+     0,
+     1,
+     MFSEL3,19,
+     NULL
+    },
+
+    // gpio 219
+    {
+     0,
+     1,
+     MFSEL3,20,
+     NULL
+    },
+
+    // gpio 220-221
+    {
+     0,
+     1,
+     MFSEL3,5,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,5,
+     NULL
+    },
+
+    // gpio 222-223
+    {
+     0,
+     1,
+     MFSEL3,6,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL3,6,
+     NULL
+    },
+
+    // gpio 224-227
+    {
+     0,
+     1,
+     MFSEL4,27,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,27,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,27,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,27,
+     NULL
+    },
+
+    // gpio 228
+    {
+     0,
+     1,
+     MFSEL4,28,
+     NULL
+    },
+
+    // gpio 229-230
+    {
+     0,
+     1,
+     MFSEL4,27,
+     NULL
+    },
+
+    {
+     0,
+     1,
+     MFSEL4,27,
+     NULL
+    },
+
+    // gpio 231
+    {
+     0,
+     1,
+     MFSEL4,9,
+     NULL
+    },
+
+    // gpio 232-255
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    },
+
+    {
+     DEF_NONE,
+     0,
+     0,0,
+     NULL
+    }
 
 };
 


### PR DESCRIPTION
1. E.g.: ipmitool raw 0x30 0x8 120
         ret: 01 00 // The pin is an output gpio and the level is low.
               01 01 // The pin is an output gpio and the level is high.
               00 01 // The pin is an input gpio and the level is high.
               00 00 // The pin is an input gpio and the level is low.

Signed-off-by: kfting <kfting@nuvoton.com>