### PR TITLE
Add PWM OEM command support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,100 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+PointerAlignment: Left
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^[<"](gtest|gmock)'
+    Priority:        5
+  - Regex:           '^"config.h"'
+    Priority:        -1
+  - Regex:           '^".*\.hpp"'
+    Priority:        1
+  - Regex:           '^<.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        4
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never
+...
+

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ Makefile
 *~
 .cscope/
 build/
+.vscode

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,19 @@
+AM_DEFAULT_SOURCE_EXT = .cpp
+
+libnuvoemcmdsdir = ${libdir}/ipmid-providers
+libnuvoemcmds_LTLIBRARIES = libnuvoemcmds.la
+libnuvoemcmds_la_SOURCES = \
+  oemcommands.cpp \
+  ipmi_pwm.cpp
+libnuvoemcmds_la_CXXFLAGS = \
+	$(SDBUSPLUS_CFLAGS) \
+	$(LIBIPMID_CFLAGS) \
+	$(PHOSPHOR_LOGGING_CFLAGS) \
+	-flto
+libnuvoemcmds_la_LDFLAGS = \
+	$(SDBUSPLUS_LIBS) \
+	$(LIBIPMID_LIBS) \
+	$(PHOSPHOR_LOGGING_LIBS) \
+	-lstdc++fs \
+	-version-info 0:0:0 -shared
+

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,62 @@
+#                                               -*- Autoconf -*-
+# Process this file with autoconf to produce a configure script.
+
+AC_PREREQ([2.69])
+AC_INIT([nuvoton-ipmi-oem], [0.1], [https://github.com/Nuvoton-Israel/nuvoton-ipmi-oem/issues])
+AC_LANG([C++])
+AC_CONFIG_HEADERS([config.h])
+AM_INIT_AUTOMAKE([subdir-objects -Wall -Werror -Wno-portability foreign dist-xz])
+
+# Checks for programs.
+AC_PROG_CXX
+AM_PROG_AR
+AC_PROG_INSTALL
+AC_PROG_MAKE_SET
+
+# Checks for typedefs, structures, and compiler characteristics.
+AC_TYPE_UINT8_T
+AX_CXX_COMPILE_STDCXX_17([noext])
+AX_APPEND_COMPILE_FLAGS([-Wall -Werror], [CXXFLAGS])
+
+# Checks for libraries.
+PKG_CHECK_MODULES([SDBUSPLUS], [sdbusplus])
+PKG_CHECK_MODULES([PHOSPHOR_LOGGING], [phosphor-logging])
+PKG_CHECK_MODULES(
+    [LIBIPMID],
+    [libipmid],
+    [],
+    [AC_MSG_ERROR([Could not find libipmid...openbmc/phosphor-host-ipmid package required])]
+)
+AC_CHECK_HEADER(
+    nlohmann/json.hpp,
+    [],
+    [AC_MSG_ERROR([Could not find nlohmann/json.hpp])]
+)
+
+# Checks for header files.
+
+
+
+# Checks for library functions.
+LT_INIT # Required for systemd linking
+
+
+PKG_PROG_PKG_CONFIG
+AC_ARG_WITH([systemdsystemunitdir],
+     [AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files])],,
+     [with_systemdsystemunitdir=auto])
+AS_IF([test "x$with_systemdsystemunitdir" = "xyes" -o "x$with_systemdsystemunitdir" = "xauto"], [
+     def_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
+
+     AS_IF([test "x$def_systemdsystemunitdir" = "x"],
+   [AS_IF([test "x$with_systemdsystemunitdir" = "xyes"],
+    [AC_MSG_ERROR([systemd support requested but pkg-config unable to query systemd package])])
+    with_systemdsystemunitdir=no],
+   [with_systemdsystemunitdir="$def_systemdsystemunitdir"])])
+AS_IF([test "x$with_systemdsystemunitdir" != "xno"],
+      [AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])])
+AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$with_systemdsystemunitdir" != "xno"])
+
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/ipmi_pwm.cpp
+++ b/ipmi_pwm.cpp
@@ -1,0 +1,316 @@
+/*
+// Copyright (c) 2020 Nuvoton Technology Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include "ipmi_pwm.hpp"
+
+#include <ipmid/api.h>
+
+#include <ipmid/api.hpp>
+#include <phosphor-logging/log.hpp>
+
+namespace ipmi
+{
+namespace nuvoton
+{
+using namespace phosphor::logging;
+// The command object path both hwmon and dbus sensor contains
+constexpr auto FAN_COMMON_OBJ_PATH = "/xyz/openbmc_project/sensors/fan_tach";
+// PWM fan sensor object path
+// constexpr auto FAN_PWM_PATH = "/xyz/openbmc_project/sensors/fan_pwm/Pwm_";
+// Dbus sensor PWM object path which implement control interface
+constexpr auto FAN_PWM_CTRL_PATH = "/xyz/openbmc_project/control/fanpwm/Pwm_";
+// TODO: check the object FanX is fixed or setting by conf?
+// Hwmon PWM object path
+constexpr auto FAN_TACH_PATH = "/xyz/openbmc_project/sensors/fan_tach/Fan";
+// Fan Pwm control interface
+constexpr auto FAN_CTRL_PWM_INTF = "xyz.openbmc_project.Control.FanPwm";
+constexpr auto FAN_PWM_PROPERTY = "Target";
+// constexpr auto SENSOR_INTF = "xyz.openbmc_project.Sensor.Value";
+// PID PWM manual mode interface and object path root
+constexpr auto PID_FAN_INTF = "xyz.openbmc_project.Control.Mode";
+constexpr auto PID_FAN_OBJ_ROOT = "/xyz/openbmc_project/settings/fanctrl";
+constexpr auto PID_MANUAL_PROPERTY = "Manual";
+
+/**
+ * @brief get the fan sensor service, which create by hwmon or dbus sensor
+ *
+ *  _fan_service:
+ *   Hwmon       => xyz.openbmc_project.Hwmon-[377141964.Hwmon1]
+ *   Dbus sensor => xyz.openbmc_project.FanSensor
+ * @return std::string the fan sensor service
+ */
+std::string IpmiPwmcontrol::getFanService()
+{
+    std::string msg, fan_service;
+    try
+    {
+        fan_service =
+            ipmi::getService(*getSdBus(), ipmi::PROP_INTF, FAN_COMMON_OBJ_PATH);
+    }
+    catch (const std::exception& e)
+    {
+        msg = "Cannot get fan tach sensor service, " + std::string(e.what());
+        log<level::ERR>(msg.c_str());
+    }
+    return fan_service;
+}
+
+uint8_t IpmiPwmcontrol::getFanServiceType()
+{
+    std::string msg;
+    // check fan service is valid first
+    if (_fan_service.empty())
+    {
+        log<level::INFO>("fan service is not valid, try to get it");
+        _fan_service = getFanService();
+    }
+    if (_fan_service.find("xyz.openbmc_project.Hwmon") != std::string::npos)
+    {
+        return fanServiceHwmon;
+    }
+    else if (_fan_service.find("xyz.openbmc_project.FanSensor") !=
+             std::string::npos)
+    {
+        return fanServiceDbusSensor;
+    }
+    log<level::ERR>("Cannot get valid fan service");
+    return fanServiceInvalid;
+}
+
+/**
+ * @brief simple util for convert double to uint8_t safe
+ *
+ * @param input the double data from sensor reading
+ * @return uint8_t the true value with type uint8_t
+ */
+uint8_t double_to_uint8(double input)
+{
+    uint8_t output;
+    char temp[8];
+
+    std::snprintf(temp, 8, "%.0f", input);
+    temp[7] = 0x00;
+    std::sscanf(temp, "%hhu", &output);
+    return output;
+}
+
+uint8_t IpmiPwmcontrol::setPwmProperty(const std::string& path,
+                                       const std::string& interface,
+                                       const std::string& property,
+                                       ipmi::Value value)
+{
+    std::string msg;
+    try
+    {
+        ipmi::setDbusProperty(*getSdBus(), _fan_service, path, interface,
+                              property, value);
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        msg = "Cannot set fan property, path:" + path + ", " +
+              std::string(e.what());
+        log<level::ERR>(msg.c_str());
+        return IPMI_CC_UNSPECIFIED_ERROR;
+    }
+    return IPMI_CC_OK;
+}
+
+/**
+ * @brief Get PWM value from Hwmon or Dbus sensor service
+ * We use the FanPwm target as value, we also need take care
+ * 1. TARGET_MODE="PWM" must set in sensor conf environment for hwmon
+ * 2. return data type is uint64, range 0~255
+ * 3. this function may not work before execute set pwm command(hwmon)
+ * ex:
+ * obj: /xyz/openbmc_project/sensors/fan_tach/Fan4 (hwmon)
+ *      /xyz/openbmc_project/control/fanpwm/Pwm_4 (dbus sensor)
+ *   xyz.openbmc_project.Control.FanPwm    interface -     -
+ *   .Target                               property  t     100
+ *
+ * @param instance the pwm id
+ * @param value the value reference, the PWM data will return here
+ * @return uint8_t IPMI status code
+ */
+uint8_t IpmiPwmcontrol::getPwmValue(uint8_t instance, uint8_t* value)
+{
+    std::string fullPath;
+    std::string msg;
+    uint64_t reading = 0;
+    switch (getFanServiceType())
+    {
+        case fanServiceHwmon:
+            fullPath = FAN_TACH_PATH + std::to_string(instance + 1);
+            break;
+        case fanServiceDbusSensor:
+            fullPath = FAN_PWM_CTRL_PATH + std::to_string(instance + 1);
+            break;
+        default:
+            return IPMI_CC_UNSPECIFIED_ERROR;
+    }
+
+    msg = "full path: " + fullPath + ", instance:" + std::to_string(instance);
+    log<level::DEBUG>(msg.c_str());
+    try
+    {
+        auto propValue =
+            ipmi::getDbusProperty(*getSdBus(), _fan_service, fullPath,
+                                  FAN_CTRL_PWM_INTF, FAN_PWM_PROPERTY);
+        reading = std::get<uint64_t>(propValue);
+    }
+    catch (const sdbusplus::exception::exception& ex)
+    {
+        msg = "Cannot get PWM from " + fullPath + ", " + std::string(ex.what());
+        log<level::ERR>(msg.c_str());
+        return IPMI_CC_INVALID;
+    }
+    *value = (uint8_t)reading;
+    return IPMI_CC_OK;
+}
+
+uint8_t IpmiPwmcontrol::setPwmValue(uint8_t instance, uint8_t value)
+{
+    switch (getFanServiceType())
+    {
+        case fanServiceHwmon:
+            return hwmonSetPwm(instance, value);
+        case fanServiceDbusSensor:
+            return dbusSetPwm(instance, value);
+        default:
+            return IPMI_CC_UNSPECIFIED_ERROR;
+    }
+}
+
+/**
+ * @brief set PWM by dbus pwm sensor dbus object property
+ * use the PWM control object path
+ * ex: /xyz/openbmc_project/control/fanpwm/Pwm_1
+ * xyz.openbmc_project.Control.FanPwm  interface -   -
+ * .Target                             property  t   255
+ *
+ * Note: the PWM sensor /xyz/openbmc_project/sensors/fan_pwm/Pwm_x
+ * is also good to get sensor reading, but it present value as percentage
+ * @param instance the PWM controller instance
+ * @param value PWM value we want to set
+ * @return uint8_t IPMI status code
+ */
+uint8_t IpmiPwmcontrol::dbusSetPwm(uint8_t instance, uint8_t value)
+{
+    std::string fullPath = FAN_PWM_CTRL_PATH + std::to_string(instance + 1);
+    std::string msg =
+        "full path: " + fullPath + ", instance:" + std::to_string(instance);
+    log<level::DEBUG>(msg.c_str());
+    uint8_t rc;
+    rc = setPwmProperty(fullPath, FAN_CTRL_PWM_INTF, FAN_PWM_PROPERTY,
+                        (uint64_t)value);
+
+    return rc;
+}
+
+uint8_t IpmiPwmcontrol::hwmonSetPwm(uint8_t instance, uint8_t value)
+{
+    std::string fullPath = FAN_TACH_PATH + std::to_string(instance + 1);
+    std::string msg =
+        "full path: " + fullPath + ", instance:" + std::to_string(instance);
+    log<level::DEBUG>(msg.c_str());
+    uint8_t rc;
+    log<level::INFO>(msg.c_str());
+    rc = setPwmProperty(fullPath, FAN_CTRL_PWM_INTF, FAN_PWM_PROPERTY,
+                        (uint64_t)value);
+
+    return rc;
+}
+
+uint8_t IpmiPwmcontrol::setManualPwm(uint8_t enabled)
+{
+    //  Get service and zone object paths
+    std::string service;
+    std::vector<std::string> objs;
+    ZoneInfo info = getPidZoneInfo();
+    if (info.first.empty())
+    {
+        log<level::WARNING>(
+            "Cannot get zone info, PID service may get some error");
+        return IPMI_CC_INVALID;
+    }
+
+    // Set manual mode for each zone
+    std::string msg;
+    try
+    {
+        for (auto it = info.second.begin(); it != info.second.end(); ++it)
+        {
+            // msg =
+            //     "set " + *it + " manual mode " +
+            //     std::to_string((bool)enabled);
+            // log<level::DEBUG>(msg.c_str());
+            ipmi::setDbusProperty(*getSdBus(), info.first, *it, PID_FAN_INTF,
+                                  PID_MANUAL_PROPERTY, (bool)enabled);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        msg = "Set fan property failed, " + std::string(e.what());
+        log<level::ERR>(msg.c_str());
+        return IPMI_CC_UNSPECIFIED_ERROR;
+    }
+
+    return IPMI_CC_OK;
+}
+
+/**
+ * @brief Get the Pid Zone Info object
+ * The getDbusObject function in ipmid will return only the
+ * first object we found, but we need all object paths.
+ *
+ * @return ZoneInfo the zone service name and object paths
+ */
+ZoneInfo IpmiPwmcontrol::getPidZoneInfo()
+{
+    ZoneInfo info =
+        std::make_pair(std::string(), std::vector<DbusObjectPath>());
+    std::string service;
+    std::vector<DbusObjectPath> objs;
+    // call dbus command to get zone object path
+    ObjectTree objectTree;
+    try
+    {
+        objectTree = ipmi::getAllDbusObjects(*getSdBus(), PID_FAN_OBJ_ROOT,
+                                             PID_FAN_INTF, "zone");
+    }
+    catch (const std::exception& e)
+    {
+        log<level::ERR>("Cannot get call dbus command to get zone object");
+        return info;
+    }
+
+    if (objectTree.empty())
+    {
+        log<level::ERR>("Cannot get any zone object");
+        return info;
+    }
+
+    // save dbus reply to zone info
+    service = objectTree.begin()->second.begin()->first;
+    for (auto it = objectTree.begin(); it != objectTree.end(); ++it)
+    {
+        objs.push_back(it->first);
+    }
+    return std::make_pair(service, objs);
+}
+
+} // namespace nuvoton
+
+} // namespace ipmi

--- a/ipmi_pwm.hpp
+++ b/ipmi_pwm.hpp
@@ -1,0 +1,54 @@
+/*
+// Copyright (c) 2020 Nuvoton Technology Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include <ipmid/utils.hpp>
+
+namespace ipmi
+{
+namespace nuvoton
+{
+enum FanServiceType
+{
+    fanServiceInvalid = 0,
+    fanServiceHwmon = 1,
+    fanServiceDbusSensor = 2,
+};
+using ZoneInfo = std::pair<DbusService, std::vector<DbusObjectPath>>;
+class IpmiPwmcontrol
+{
+  public:
+    IpmiPwmcontrol() {};
+    ~IpmiPwmcontrol() = default;
+
+    uint8_t getFanServiceType();
+    uint8_t getPwmValue(uint8_t instance, uint8_t* value);
+    uint8_t setPwmValue(uint8_t instance, uint8_t value);
+    uint8_t setPwmProperty(const std::string& path,
+                           const std::string& interface,
+                           const std::string& property, ipmi::Value value);
+    uint8_t setManualPwm(uint8_t enabled);
+
+  private:
+    std::string _fan_service = "";
+    uint8_t dbusSetPwm(uint8_t instance, uint8_t value);
+    uint8_t hwmonSetPwm(uint8_t instance, uint8_t value);
+    std::string getFanService();
+    ZoneInfo getPidZoneInfo();
+};
+
+} // namespace nuvoton
+
+} // namespace ipmi

--- a/oemcommands.cpp
+++ b/oemcommands.cpp
@@ -1,0 +1,76 @@
+/*
+// Copyright (c) 2020 Nuvoton Technology Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include "oemcommands.hpp"
+
+#include <ipmid/api.hpp>
+#include <phosphor-logging/log.hpp>
+
+namespace ipmi
+{
+using namespace phosphor::logging;
+
+namespace nuvoton
+{
+ipmi::RspType<> ipmiOEMSetManualPwm(uint8_t enabled)
+{
+    uint8_t rc;
+    rc = pwm_control->setManualPwm(enabled);
+    return ipmi::response(rc);
+}
+
+ipmi::RspType<uint8_t> ipmiOEMGetPwm(uint8_t pwm_id)
+{
+    uint8_t value, rc;
+    rc = pwm_control->getPwmValue(pwm_id, &value);
+    return ipmi::response(rc, value);
+}
+
+ipmi::RspType<uint8_t> ipmiOEMSetPwm(uint8_t pwm_id, uint8_t value)
+{
+    uint8_t rc = pwm_control->setPwmValue(pwm_id, value);
+    return ipmi::response(rc, value);
+}
+
+void createPwmControl()
+{
+    pwm_control = std::make_unique<IpmiPwmcontrol>();
+}
+
+} // namespace nuvoton
+
+static void registerOEMFunctions() __attribute__((constructor));
+
+static void registerOEMFunctions(void)
+{
+    log<level::INFO>("Registering Nuvoton IPMI OEM commands");
+
+    nuvoton::createPwmControl();
+
+    // <Set Manual PWM command>
+    registerHandler(prioOemBase, netFnOemThree, nuvoton::fan::cmdSetManualPwm,
+                    Privilege::Callback, nuvoton::ipmiOEMSetManualPwm);
+
+    // <Get PWM value command>
+    registerHandler(prioOemBase, netFnOemThree, nuvoton::fan::cmdGetPwm,
+                    Privilege::Callback, nuvoton::ipmiOEMGetPwm);
+
+    // <Set PWM value  command>
+    registerHandler(prioOemBase, netFnOemThree, nuvoton::fan::cmdSetPwm,
+                    Privilege::Callback, nuvoton::ipmiOEMSetPwm);
+}
+
+} // namespace ipmi

--- a/oemcommands.hpp
+++ b/oemcommands.hpp
@@ -1,0 +1,43 @@
+/*
+// Copyright (c) 2020 Nuvoton Technology Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#pragma once
+
+#include "ipmi_pwm.hpp"
+
+#include <ipmid/api-types.hpp>
+
+namespace ipmi
+{
+namespace nuvoton
+{
+
+namespace fan
+{
+static constexpr Cmd cmdSetManualPwm = 0x90;
+static constexpr Cmd cmdGetPwm = 0x92;
+static constexpr Cmd cmdSetPwm = 0x91;
+} // namespace fan
+
+std::unique_ptr<IpmiPwmcontrol> pwm_control;
+void createPwmControl();
+ipmi::RspType<> ipmiOEMSetManualPwm(uint8_t enabled);
+ipmi::RspType<uint8_t> ipmiOEMGetPwm(uint8_t pwm_id);
+ipmi::RspType<uint8_t> ipmiOEMSetPwm(uint8_t pwm_id, uint8_t value);
+
+} // namespace nuvoton
+
+} // namespace ipmi


### PR DESCRIPTION
NetFn: 0x34
Commands:
  0x90 [enabled] : enable/disable PID manual mode
  0x91 [fan id] [value] :set pwm value to fan
  0x92 [fan id] : get the pwm value we set from the fan

Note. the read pwm function may not get real sysfs pwm value if
we use hwmon. The pwm target read function is not implemented
in hwmon, user can only get the pwm value user set before.

Usage:
~# ipmitool raw 0x34 0x90 0x1

~# ipmitool raw 0x34 0x91 0x3 0x64
 64
~# ipmitool raw 0x34 0x92 0x3
 64
~# ipmitool raw 0x34 0x90 0x0

Signed-off-by: Brian Ma <chma0@nuvoton.com>