### PR TITLE
Add get pwm mode command and move fan Fn to 0x32

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Please include the recipe **nuvoton-ipmi-oem** in the packagegroups and make the
 |Name  | NetFn | Commmand | Requst Data [byte]|  Return Data| Description |
 |------|---|---|---------|-----------|----------------|
 | Set PID manual mode for all zones | 0x34| 0x90| [enabled]| - | enabled set 0x01 to enter manaul mode; 0x0 to exit manual mode for all PID zones|
-| Set PWM |0x34| 0x91| [pwm_id] [value] | [set_value]| set specific pwm with value 0x0 ~ 0xff|
-| Read PWM |0x34| 0x92| [pwm_id] |[pwm_value]| read specific pwm value|
+| Get PID manual mode |0x32| 0x89| - |[mode]| 0:automatic mode, 1: manual mode|
+| Set PWM |0x32| 0x91| [pwm_id] [value] | [set_value]| set specific pwm with value 0x0 ~ 0xff|
+| Read PWM |0x32| 0x92| [pwm_id] |[pwm_value]| read specific pwm value|
 | Get BIOS post code| 0x34 | 0x73 | - | [post code]||
 | Get firmware version | 0x34 | 0x0b | [fw_type] | [major] [minor] | fw_type:<br> 00h - BIOS<br>01h - CPLD<br>02h - BMC<br>03h - PSU |
 | Get GPIO status| 0x30 | 0xE1 | [pin_number] | [direction] [value]| return valid GPIO pin status, direction: 1=output, 0=input|
@@ -26,16 +27,19 @@ Please include the recipe **nuvoton-ipmi-oem** in the packagegroups and make the
 ### Manual change PWM value
 ```bash
 # enter manual mode to avoid PID control change pwm value
-$ ipmitool raw 0x34 0x90 0x1
+$ ipmitool raw 0x32 0x90 0x1
 
 # set pwm 4 value 0x64
-$ ipmitool raw 0x34 0x91 0x3 0x64
+$ ipmitool raw 0x32 0x91 0x3 0x64
  64
 # get pwm value from pwm 4
-$ ipmitool raw 0x34 0x92 0x3
+$ ipmitool raw 0x32 0x92 0x3
  64
 # exit manual mode
-$ ipmitool raw 0x34 0x90 0x0
+$ ipmitool raw 0x32 0x90 0x0
+# check we are in automatic mode
+$ ipmitool raw 0x32 0x89
+ 00
 ```
 
 ### Get BIOS post code

--- a/ipmi_pwm.hpp
+++ b/ipmi_pwm.hpp
@@ -40,6 +40,7 @@ class IpmiPwmcontrol
                            const std::string& interface,
                            const std::string& property, ipmi::Value value);
     uint8_t setManualPwm(uint8_t enabled);
+    uint8_t getPwmMode(uint8_t* value);
 
   private:
     std::string _fan_service = "";

--- a/oemcommands.cpp
+++ b/oemcommands.cpp
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 */
-
 #include "oemcommands.hpp"
 
 #include <ipmid/api.hpp>
@@ -30,6 +29,13 @@ using namespace phosphor::logging;
 
 namespace nuvoton
 {
+ipmi::RspType<uint8_t> ipmiOEMGetPwmMode()
+{
+    uint8_t rc, value;
+    rc = pwm_control->getPwmMode(&value);
+    return ipmi::response(rc, value);
+}
+
 ipmi::RspType<> ipmiOEMSetManualPwm(uint8_t enabled)
 {
     uint8_t rc;
@@ -223,16 +229,20 @@ static void registerOEMFunctions(void)
 
     nuvoton::createPwmControl();
 
+    // <Get Manual PWM command>
+    registerHandler(prioOemBase, netFnOemTwo, nuvoton::fan::cmdGetPwmMode,
+                    Privilege::Callback, nuvoton::ipmiOEMGetPwmMode);
+
     // <Set Manual PWM command>
-    registerHandler(prioOemBase, netFnOemThree, nuvoton::fan::cmdSetManualPwm,
+    registerHandler(prioOemBase, netFnOemTwo, nuvoton::fan::cmdSetManualPwm,
                     Privilege::Callback, nuvoton::ipmiOEMSetManualPwm);
 
     // <Get PWM value command>
-    registerHandler(prioOemBase, netFnOemThree, nuvoton::fan::cmdGetPwm,
+    registerHandler(prioOemBase, netFnOemTwo, nuvoton::fan::cmdGetPwm,
                     Privilege::Callback, nuvoton::ipmiOEMGetPwm);
 
-    // <Set PWM value  command>
-    registerHandler(prioOemBase, netFnOemThree, nuvoton::fan::cmdSetPwm,
+    // <Set PWM value command>
+    registerHandler(prioOemBase, netFnOemTwo, nuvoton::fan::cmdSetPwm,
                     Privilege::Callback, nuvoton::ipmiOEMSetPwm);
 
     // Get BIOS post code

--- a/oemcommands.hpp
+++ b/oemcommands.hpp
@@ -41,6 +41,7 @@ enum FirmwareType : uint8_t
 
 namespace fan
 {
+static constexpr Cmd cmdGetPwmMode = 0x89;
 static constexpr Cmd cmdSetManualPwm = 0x90;
 static constexpr Cmd cmdGetPwm = 0x92;
 static constexpr Cmd cmdSetPwm = 0x91;
@@ -52,6 +53,7 @@ static constexpr Cmd cmdGetGpioStatus = 0xE1;
 
 std::unique_ptr<IpmiPwmcontrol> pwm_control;
 void createPwmControl();
+ipmi::RspType<uint8_t> ipmiOEMGetPwmMode();
 ipmi::RspType<> ipmiOEMSetManualPwm(uint8_t enabled);
 ipmi::RspType<uint8_t> ipmiOEMGetPwm(uint8_t pwm_id);
 ipmi::RspType<uint8_t> ipmiOEMSetPwm(uint8_t pwm_id, uint8_t value);


### PR DESCRIPTION
Add command 0x89 to get PWM in manual mode or not.
Also move PWM command NetFn from 0x34 to 0x32.

Example:
$ ipmitool raw 0x32 0x89
 00
$ ipmitool raw 0x32 0x90 0x01

$ ipmitool raw 0x32 0x89
 01

Signed-off-by: Brian Ma <chma0@nuvoton.com>