### PR TITLE
Support read PSU version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,7 @@ libnuvoemcmds_LTLIBRARIES = libnuvoemcmds.la
 libnuvoemcmds_la_SOURCES = \
   oemcommands.cpp \
   ipmi_pwm.cpp \
+  ipmi_fw.cpp \
   gpio_oem.cpp
 libnuvoemcmds_la_CXXFLAGS = \
 	$(SDBUSPLUS_CFLAGS) \

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please include the recipe **nuvoton-ipmi-oem** in the packagegroups and make the
 | Set PWM |0x32| 0x91| [pwm_id] [value] | [set_value]| set specific pwm with value 0x0 ~ 0xff|
 | Read PWM |0x32| 0x92| [pwm_id] |[pwm_value]| read specific pwm value|
 | Get BIOS post code| 0x34 | 0x73 | - | [post code]||
-| Get firmware version | 0x34 | 0x0b | [fw_type] | [bytes length] [version] | fw_type:<br> 00h - BIOS<br>01h - CPLD<br>02h - BMC<br>03h - PSU<br/>Return data: first byte is length of version string, from second to final byte are version string presented as ASCII hex |
+| Get firmware version | 0x34 | 0x0b | [fw_type] | [bytes length] [version] | fw_type:<br> 00h - BIOS<br>01h - CPLD<br>02h - BMC<br>03h - PSU<br/>Return data: version string presented as ASCII hex |
 | Get GPIO status| 0x30 | 0xE1 | [pin_number] | [direction] [value]| return valid GPIO pin status, direction: 1=output, 0=input|
 
 ## Exmples
@@ -53,13 +53,15 @@ root@evb-npcm845:~# ipmitool raw 0x34 0x73
 ```bash
 # BMC version is 2.12.0-dev-1361-gb4e63f50d-dirty
 root@evb-npcm845:~# ipmitool raw 0x34 0x0b 0x02
- 20 32 2e 31 32 2e 30 2d 64 65 76 2d 31 33 36 31
- 2d 67 62 34 65 36 33 66 35 30 64 2d 64 69 72 74
- 79
+ 32 2e 31 31 2e 30 2d 31 30 32 2d 67 63 31 34 35
+ 33 30 37 63 64 2d 64 69 72 74 79
 # BIOS version is C2195.0.BS.1A06.GN.3
 root@evb-npcm845:~# ipmitool raw 0x34 0x0b 0x00
- 14 43 32 31 39 35 2e 30 2e 42 53 2e 31 41 30 36
- 2e 47 4e 2e 33
+ 43 32 31 39 35 2e 30 2e 42 53 2e 31 41 30 36 2e
+ 47 4e 2e 33
+ # PSU version is 14133800
+ root@scm-npcm845:~# ipmitool raw 0x34 0x0b 0x03
+ 31 34 31 33 31 38 30 30
 ```
 
 # Get GPIO status

--- a/ipmi_fw.cpp
+++ b/ipmi_fw.cpp
@@ -1,0 +1,368 @@
+#include "ipmi_fw.hpp"
+
+#include <linux/i2c-dev.h>
+#include <linux/i2c.h>
+#include <sys/ioctl.h>
+
+#include <fstream>
+#include <iostream>
+#include <ipmid/api.hpp>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/log.hpp>
+#include <stdexcept>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+namespace ipmi
+{
+namespace nuvoton
+{
+using namespace phosphor::logging;
+using Json = nlohmann::json;
+using InternalFailure =
+    sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+
+static constexpr auto psu_update = "/usr/bin/update_psu";
+static constexpr auto PSUImagePath = "/var/wcs/home/";
+// TODO: use entity config instead of define a new configuration
+static constexpr auto FwConfig = "/usr/share/ipmi-providers/fw.json";
+static constexpr auto FwBusType = "bus";
+static constexpr auto FwAddressType = "address";
+static const std::string space = " ";
+// static std::string PSUBus = "7";
+// static std::string PSUAddress = "0x58";
+static constexpr auto I2C_DEV = "/dev/i2c-";
+
+Json parseJSONConfig(const std::string& configFile)
+{
+    std::ifstream jsonFile(configFile);
+    if (!jsonFile.is_open())
+    {
+        log<level::ERR>("Temperature readings JSON file not found");
+        elog<InternalFailure>();
+    }
+
+    auto data = Json::parse(jsonFile, nullptr, false);
+    if (data.is_discarded())
+    {
+        log<level::ERR>("Temperature readings JSON parser failure");
+        elog<InternalFailure>();
+    }
+
+    return data;
+}
+
+typedef struct
+{
+    std::string bus;
+    uint16_t address;
+} FW_CONFIG;
+
+int readFwConfig(std::string target, FW_CONFIG& fw_config)
+{
+    std::string bus, address, msg;
+    try
+    {
+        Json data = parseJSONConfig(FwConfig);
+        auto config = data.find(target);
+        if (config != data.end())
+        {
+            bus = (*config).value(FwBusType, bus);
+            address = (*config).value(FwAddressType, address);
+            fw_config.address = (uint16_t)std::stoul(address, nullptr, 16);
+            ;
+            fw_config.bus = bus;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        log<level::ERR>(e.what());
+        return -1;
+    }
+    msg = target + " bus: " + bus + ", address: " + address;
+    log<level::INFO>(msg.c_str());
+    return 0;
+}
+
+// TBD: wait for implement
+ipmi::RspType<> psuFwUpdate(std::string image)
+{
+    std::string msg = "psuFwUpdate: " + image;
+    log<level::INFO>(msg.c_str());
+    /*if (readFwConfig() != 0)
+    {
+        log<level::ERR>("Cannot read PSU config to get bus and address");
+        return ipmi::responseUnspecifiedError();
+    }
+    std::string cmd = psu_update + space + PSUBus + space + PSUAddress + space +
+                      std::string(PSUImagePath) + image;
+    // exec may cause timeout, use service to implement
+    // ipmi_dbus_sendrecv: failed to send dbus message (Connection timed out)
+    try
+    {
+        log<level::INFO>(cmd.c_str());
+        std::string result = exec(cmd.c_str());
+        log<level::INFO>(result.c_str());
+    }
+    catch (const std::exception& e)
+    {
+        log<level::ERR>(e.what());
+        return ipmi::responseUnspecifiedError();
+    }
+    return ipmi::responseSuccess();*/
+    return ipmi::responseCmdFailFwUpdMode();
+}
+
+// TBD: wait for implement
+ipmi::RspType<> psuFwStatus(uint8_t region)
+{
+    log<level::INFO>("psuFwStatus");
+    return ipmi::responseCmdFailFwUpdMode();
+}
+
+// TBD: wait for implement
+ipmi::RspType<> psuFwAbort(uint8_t region)
+{
+    log<level::INFO>("psuFwAbort");
+    return ipmi::responseCmdFailFwUpdMode();
+}
+
+ipmi::RspType<> ipmiOemPsuFwUpdate(uint8_t region, uint8_t action,
+                                   std::string image)
+{
+    switch (action)
+    {
+        case as_int(FirmwareAction::ACTIVE):
+            return psuFwUpdate(image);
+        case as_int(FirmwareAction::STATUS):
+            return psuFwStatus(region);
+        case as_int(FirmwareAction::ABORT):
+            return psuFwAbort(region);
+        default:
+            return ipmi::responseUnspecifiedError();
+    }
+}
+
+std::string exec(const char* cmd)
+{
+    char buffer[128];
+    std::string result = "";
+    FILE* pipe = popen(cmd, "r");
+    if (!pipe)
+        throw std::runtime_error("popen() failed!");
+    try
+    {
+        while (fgets(buffer, sizeof buffer, pipe) != NULL)
+        {
+            result += buffer;
+        }
+    }
+    catch (...)
+    {
+        pclose(pipe);
+        throw;
+    }
+    pclose(pipe);
+    return result;
+}
+
+int fw_open_i2c(std::string i2c_bus)
+{
+    std::string i2c_dev = I2C_DEV + i2c_bus;
+    int i2cdev = open(i2c_dev.c_str(), O_RDWR);
+    if (i2cdev < 0)
+    {
+        std::string msg = "Cannot open Fw I2C device: " + i2c_dev;
+        log<level::ERR>(msg.c_str());
+    }
+    return i2cdev;
+}
+
+namespace psu
+{
+static constexpr auto FW_INFO_LENGTH = 11;
+static constexpr auto PSU_SERVICE = "psu_update.service";
+static constexpr auto SYSTEMD_BUSNAME = "org.freedesktop.systemd1";
+static constexpr auto SYSTEMD_PATH = "/org/freedesktop/systemd1";
+static constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
+
+struct FW_INFO
+{
+    uint8_t length;
+    uint8_t active;
+    char revision[]; // unit8, for eaiser convert to string
+} __attribute__((packed));
+
+int read_fw_info(int i2cdev, int address, uint8_t image, std::string& ver,
+                 uint8_t* active)
+{
+    struct i2c_rdwr_ioctl_data i2c_rdwr;
+    struct i2c_msg i2cmsg[2];
+    uint8_t buf[32];
+    int ret;
+    std::string msg;
+
+    buf[0] = 0xEF;
+    buf[1] = 0x1;
+    buf[2] = image;
+
+    i2cmsg[0].addr = address;
+    i2cmsg[0].flags = 0x00; // write
+    i2cmsg[0].len = 3;
+    i2cmsg[0].buf = buf;
+
+    i2cmsg[1].addr = address;
+    i2cmsg[1].flags = I2C_M_RD; // read
+    i2cmsg[1].len = FW_INFO_LENGTH;
+    i2cmsg[1].buf = buf;
+
+    i2c_rdwr.msgs = i2cmsg;
+    i2c_rdwr.nmsgs = 2;
+    ret = ioctl(i2cdev, I2C_RDWR, &i2c_rdwr);
+    if (ret < 0)
+    {
+        msg = "read_fw_info: i2c err ret =" + std::to_string(ret);
+        log<level::ERR>(msg.c_str());
+        return ret;
+    }
+    auto info = reinterpret_cast<FW_INFO*>(buf);
+    ver = std::string(info->revision, info->length - 1);
+    *active = info->active;
+
+    return 0;
+}
+
+int getPsuVersionInfo(ipmi::Context::ptr& ctx, std::string& ver)
+{
+    std::string rev;
+    uint8_t active;
+    int ret = -1;
+    FW_CONFIG config;
+
+    // read PSU bus and address
+    if (readFwConfig(std::string("PSU"), config) != 0)
+        return ret;
+
+    // get version from dbus first?
+
+    // read PSU versions
+    int i2cdev = fw_open_i2c(config.bus);
+    if (i2cdev > 0)
+    {
+        // Read A image first
+        ret = psu::read_fw_info(i2cdev, config.address, 0xA, rev, &active);
+        if (ret == 0 && active > 0)
+        {
+            ver = rev;
+        }
+        else
+        {
+            // If A image is not active, read B image
+            ret = psu::read_fw_info(i2cdev, config.address, 0xB, rev, &active);
+            if (ret == 0 && active > 0)
+            {
+                ver = rev;
+            }
+            // somthing goes wrong, A/B inactive
+            else
+            {
+                log<level::ERR>("Cannot get active image!");
+                if (ret == 0)
+                {
+                    ret = -1;
+                }
+            }
+        }
+        close(i2cdev);
+    }
+    return ret;
+}
+
+void startflashPsu(sdbusplus::bus::bus& bus)
+{
+    auto method = bus.new_method_call(SYSTEMD_BUSNAME, SYSTEMD_PATH,
+                                      SYSTEMD_INTERFACE, "StartUnit");
+    method.append(PSU_SERVICE, "replace");
+    try
+    {
+        auto reply = bus.call(method);
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        log<level::ERR>(e.what());
+        elog<InternalFailure>();
+    }
+}
+} // namespace psu
+
+namespace cpld
+{
+static const std::string CPLD = "CPLD";
+static const std::string SCM_CPLD = "DC-SCM CPLD";
+static constexpr auto FW_INFO_LENGTH = 2;
+
+// TBD, we have no CPLD spec yet
+int read_clpd_version(int i2cdev, u_int16_t address, std::string& ver)
+{
+    struct i2c_rdwr_ioctl_data i2c_rdwr;
+    struct i2c_msg i2cmsg[2];
+    uint8_t buf[4];
+    int ret;
+    std::string msg;
+
+    buf[0] = 0x0;
+
+    i2cmsg[0].addr = address;
+    i2cmsg[0].flags = 0x00; // write
+    i2cmsg[0].len = 1;
+    i2cmsg[0].buf = buf;
+
+    i2cmsg[1].addr = address;
+    i2cmsg[1].flags = I2C_M_RD; // read
+    i2cmsg[1].len = FW_INFO_LENGTH;
+    i2cmsg[1].buf = buf;
+
+    i2c_rdwr.msgs = i2cmsg;
+    i2c_rdwr.nmsgs = 2;
+    ret = ioctl(i2cdev, I2C_RDWR, &i2c_rdwr);
+    if (ret < 0)
+    {
+        msg = "read_fw_info: i2c err ret =" + std::to_string(ret);
+        log<level::ERR>(msg.c_str());
+        return ret;
+    }
+    // cast uint8 to char to build string
+    ver = std::string(reinterpret_cast<const char*>(buf), FW_INFO_LENGTH);
+
+    return 0;
+}
+
+int getCpldVersionInfo(ipmi::Context::ptr& ctx, std::string& ver,
+                       uint8_t fw_type)
+{
+    std::string cfg_typename;
+    int ret = -1;
+    FW_CONFIG config;
+    if (fw_type == as_int(FirmwareType::CPLD))
+        cfg_typename = CPLD;
+    else
+        cfg_typename = SCM_CPLD;
+
+    if (readFwConfig(cfg_typename, config) != 0)
+        return ret;
+
+    int i2cdev = fw_open_i2c(config.bus);
+    if (i2cdev > 0)
+    {
+        ret = read_clpd_version(i2cdev, config.address, ver);
+        close(i2cdev);
+    }
+    return ret;
+}
+
+} // namespace cpld
+
+} // namespace nuvoton
+
+} // namespace ipmi

--- a/ipmi_fw.hpp
+++ b/ipmi_fw.hpp
@@ -1,0 +1,58 @@
+#pragma once
+#include <ipmid/api.hpp>
+
+namespace ipmi
+{
+namespace nuvoton
+{
+
+enum class FirmwareType : uint8_t
+{
+    BIOS = 0,
+    CPLD = 1,
+    BMC = 2,
+    PSU = 3,
+    SCM_CPLD = 7,
+};
+
+enum class FirmwareTarget : uint8_t
+{
+    PSU = 0x11,
+};
+
+enum class FirmwareAction : uint8_t
+{
+    ACTIVE = 1,
+    ABORT = 2,
+    STATUS = 3,
+};
+
+template <typename Enumeration>
+constexpr auto as_int(Enumeration const value) ->
+    typename std::underlying_type<Enumeration>::type
+{
+    return static_cast<typename std::underlying_type<Enumeration>::type>(value);
+}
+
+int fw_open_i2c(std::string i2c_bus);
+std::string exec(const char* cmd);
+
+namespace psu
+{
+int read_fw_info(int i2cdev, int address, uint8_t image, std::string& ver,
+                 uint8_t* active);
+int getPsuVersionInfo(ipmi::Context::ptr& ctx, std::string& ver);
+void startflashPsu(sdbusplus::bus::bus& bus);
+void subscribeToSystemdSignals(sdbusplus::bus::bus& bus);
+void unsubscribeFromSystemdSignals(sdbusplus::bus::bus& bus);
+} // namespace psu
+
+namespace cpld
+{
+int getCpldVersionInfo(ipmi::Context::ptr& ctx, std::string& ver,
+                       uint8_t fw_type);
+} // namespace cpld
+
+} // namespace nuvoton
+
+} // namespace ipmi

--- a/oemcommands.hpp
+++ b/oemcommands.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "ipmi_fw.hpp"
 #include "ipmi_pwm.hpp"
 
 #include <ipmid/api-types.hpp>
@@ -31,14 +32,6 @@ typedef struct
     char minor;
 } Revision;
 
-enum FirmwareType : uint8_t
-{
-    BIOS = 0,
-    CPLD,
-    BMC,
-    PSU,
-};
-
 namespace fan
 {
 static constexpr Cmd cmdGetPwmMode = 0x89;
@@ -49,6 +42,7 @@ static constexpr Cmd cmdSetPwm = 0x91;
 
 static constexpr Cmd cmdGetFimwareVer = 0x0b;
 static constexpr Cmd cmdGetPostCode = 0x73;
+static constexpr Cmd cmdFirmwareUpdate = 0x84;
 static constexpr Cmd cmdGetGpioStatus = 0xE1;
 
 std::unique_ptr<IpmiPwmcontrol> pwm_control;
@@ -58,6 +52,8 @@ ipmi::RspType<> ipmiOEMSetManualPwm(uint8_t enabled);
 ipmi::RspType<uint8_t> ipmiOEMGetPwm(uint8_t pwm_id);
 ipmi::RspType<uint8_t> ipmiOEMSetPwm(uint8_t pwm_id, uint8_t value);
 ipmi::RspType<uint8_t, uint8_t> ipmiOEMGetGpioStatus(uint8_t pinNum);
+ipmi::RspType<> ipmiOemPsuFwUpdate(uint8_t region, uint8_t action,
+                                   std::string image);
 
 } // namespace nuvoton
 

--- a/script/version_verify.py
+++ b/script/version_verify.py
@@ -6,12 +6,24 @@
 #   equals: echo "14 43 32 31 39 35 2e" | xxd -r -p
 #   Or convert version string to ipmid format:
 #   python ./version_verify.py -r C2195.0.BS.1A06.GN.3
+#   Or read PSU version from i2c transfer
+#   echo "0x30 0x39 0x31 0x32 0x31 0x37 0x30 0x30" |./version_verify.py -s -b
 
 import os
 import sys
 import argparse
 
+def convert_byte_prefix(data, length_byte):
+    ver = bytearray()
+    for line in data:
+        ver += bytearray(int(x, 16) for x in line.strip().split(" "))
+    if (length_byte):
+        return ver[1:].decode('utf-8')
+    return ver.decode('utf-8')
+
 def convert_byte(data, length_byte):
+    if (data[0].strip().startswith("0x")):
+        return convert_byte_prefix(data, length_byte)
     ver = bytearray()
     for line in data:
         ver += bytearray.fromhex(line)
@@ -20,19 +32,22 @@ def convert_byte(data, length_byte):
     return ver.decode('utf-8')
 
 def convert_byte_stdin(length_byte):
-    return convert_byte(sys.stdin, length_byte)
+    return convert_byte(sys.stdin.readlines(), length_byte)
 
 def convert_byte_file(file, length_byte):
     with open(file) as f:
         data = f.readlines()
         return convert_byte(data, length_byte)
 
-def print_hex(ver, length_byte):
+def print_hex(ver, length_byte, prefix):
     # insert length byte if need
     if length_byte:
         ver = bytes([len(ver)]).decode('utf-8') + ver
     # convert string to hex format, and split each byte by space
-    data = " ".join("{:02x}".format(ord(c)) for c in ver)
+    if (prefix):
+        data = " ".join("0x{:02x}".format(ord(c)) for c in ver)
+    else:
+        data = " ".join("{:02x}".format(ord(c)) for c in ver)
     # print new line for each 16 bytes to match format as ipmid
     data_bytes = data.split(" ")
     lines = []
@@ -62,6 +77,14 @@ def main():
         help="convert version string to bytes"
     )
     parser.add_argument(
+        '-p', '--prefix', dest='prefix', action="store_true",
+        help="convert version string to bytes with prefix"
+    )
+    parser.add_argument(
+        '-b', '--length', dest='bc', action="store_false",
+        help="set first byte as string length"
+    )
+    parser.add_argument(
         '-v', '--verbose', dest='verb', action="store_true",
         help="show verbose messages"
     )
@@ -70,19 +93,20 @@ def main():
 
     # dump arguments
     global VERBOSE
-    byte_count = True
+    byte_count = args.bc
     if args.verb:
         print("input file     : {}".format(args.file))
         print("process length : {}".format(byte_count))
+        print("to hex string  : {}".format(args.revert or args.prefix))
         VERBOSE = args.verb
     if args.stdin:
         ver = convert_byte_stdin(byte_count)
-    elif args.revert:
+    elif args.revert or args.prefix:
         if (len(args.file) == 0):
             print("Input string should not be empty!!\n")
             # parser.print_help()
             return
-        ver = print_hex(args.file, byte_count)
+        ver = print_hex(args.file, byte_count, args.prefix)
     else:
         if (not (os.path.isfile(args.file))):
             sys.exit("Can not find input file " + args.file)


### PR DESCRIPTION
First we defined the PSU bus and address in file:
"/usr/share/ipmi-providers/fw.json" like:
{
  "PSU":
  {
    "bus" : "7",
    "address" : "0x58"
  },
...

Example:
root@scm-npcm845:~# ipmitool raw 0x34 0x0b 0x03
 31 34 31 33 31 38 30 30

And also we remove the return version first byte count. Instead, the
return data only contains version string.

Signed-off-by: Brian Ma <chma0@nuvoton.com>