### PR TITLE
Move command code fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Please include the recipe **nuvoton-ipmi-oem** in the packagegroups and make the
 | Get PID manual mode |0x32| 0x89| - |[mode]| 0:automatic mode, 1: manual mode|
 | Set PWM |0x32| 0x91| [pwm_id] [value] | [set_value]| set specific pwm with value in range: 0x0 ~ 0x64|
 | Read PWM |0x32| 0x92| [pwm_id] |[pwm_value]| read specific pwm value|
-| Get BIOS post code| 0x34 | 0x73 | - | [post code]||
-| Get firmware version | 0x34 | 0x0b | [fw_type] | [bytes length] [version] | fw_type:<br> 00h - BIOS<br>01h - CPLD<br>02h - BMC<br>03h - PSU<br/>Return data: version string presented as ASCII hex |
+| Get BIOS post code| 0x32 | 0x73 | - | [post code]||
+| Get firmware version | 0x38 | 0x0b | [fw_type] | [bytes length] [version] | fw_type:<br> 00h - BIOS<br>01h - CPLD<br>02h - BMC<br>03h - PSU<br/>Return data: version string presented as ASCII hex |
 | Get GPIO status| 0x30 | 0xE1 | [pin_number] | [direction] [value]| return valid GPIO pin status, direction: 1=output, 0=input|
 
 ## Exmples

--- a/ipmi_fw.cpp
+++ b/ipmi_fw.cpp
@@ -300,7 +300,7 @@ namespace cpld
 {
 static const std::string CPLD = "CPLD";
 static const std::string SCM_CPLD = "DC-SCM CPLD";
-static constexpr auto FW_INFO_LENGTH = 2;
+static constexpr auto FW_INFO_LENGTH = 1;
 
 // TBD, we have no CPLD spec yet
 int read_clpd_version(int i2cdev, u_int16_t address, std::string& ver)
@@ -315,7 +315,7 @@ int read_clpd_version(int i2cdev, u_int16_t address, std::string& ver)
 
     i2cmsg[0].addr = address;
     i2cmsg[0].flags = 0x00; // write
-    i2cmsg[0].len = 1;
+    i2cmsg[0].len = 1;      // CPLD version cmd: 0x0
     i2cmsg[0].buf = buf;
 
     i2cmsg[1].addr = address;
@@ -333,7 +333,8 @@ int read_clpd_version(int i2cdev, u_int16_t address, std::string& ver)
         return ret;
     }
     // cast uint8 to char to build string
-    ver = std::string(reinterpret_cast<const char*>(buf), FW_INFO_LENGTH);
+    //ver = std::string(reinterpret_cast<const char*>(buf), FW_INFO_LENGTH);
+    ver = std::to_string(buf[0]);
 
     return 0;
 }

--- a/oemcommands.cpp
+++ b/oemcommands.cpp
@@ -247,7 +247,7 @@ ipmi::RspType<std::vector<char>>
         case as_int(FirmwareType::CPLD):
         case as_int(FirmwareType::SCM_CPLD):
             res = cpld::getCpldVersionInfo(ctx, version, type);
-            //return ipmi::responseDestinationUnavailable();
+            // return ipmi::responseDestinationUnavailable();
             break;
         case as_int(FirmwareType::PSU):
             res = psu::getPsuVersionInfo(ctx, version);
@@ -321,11 +321,11 @@ static void registerOEMFunctions(void)
                     Privilege::Callback, nuvoton::ipmiOEMSetPwm);
 
     // Get BIOS post code
-    registerHandler(prioOemBase, netFnOemThree, nuvoton::cmdGetPostCode,
+    registerHandler(prioOemBase, netFnOemTwo, nuvoton::cmdGetPostCode,
                     Privilege::User, nuvoton::ipmiOEMGetPostCode);
 
     // Get firmware version
-    registerHandler(prioOemBase, netFnOemThree, nuvoton::cmdGetFimwareVer,
+    registerHandler(prioOemBase, netFnOemFive, nuvoton::cmdGetFimwareVer,
                     Privilege::User, nuvoton::ipmiOEMGetFirmwareVersion);
 
     // <Get GPIO status command>


### PR DESCRIPTION
Move cmd: "Get BIOS Code" fn from 0x34 to 0x32
Move cmd: "Get Firmware Version" fn from 0x34 to 0x38

Signed-off-by: Brian Ma <chma0@nuvoton.com>